### PR TITLE
Fix the reroll() to starts the animation from the beginning

### DIFF
--- a/src/DiceBox.js
+++ b/src/DiceBox.js
@@ -988,7 +988,8 @@ class DiceBox {
 	async reroll(diceIdArray) {
 		this.rolling = true;
 		this.running = Date.now();
-		this.iteration = 0
+		this.iteration = 0;
+		this.last_time = 0; // fix the animation: starts from the beginning 
 		return new Promise((resolve,reject) => {
 			diceIdArray.forEach(dieId => {
 				const dicemesh = this.diceList[dieId]
@@ -1144,5 +1145,6 @@ class DiceBox {
 
 	}
 }
+
 
 export { DiceBox }


### PR DESCRIPTION
The reroll() function should reset itself on time (i.e. last_time = 0), otherwise when it is triggered (i.e. through a click), the animation fails because it starts later in time.